### PR TITLE
Upgrade docs 2.0.0

### DIFF
--- a/manifests/deployment-backend.yaml
+++ b/manifests/deployment-backend.yaml
@@ -17,7 +17,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: docs
-          image: lasuite/impress-backend:v1.10.0
+          image: lasuite/impress-backend:v2.0.0
           securityContext:
             runAsUser: 0
           command:

--- a/manifests/deployment-frontend.yaml
+++ b/manifests/deployment-frontend.yaml
@@ -17,7 +17,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: docs
-          image: lasuite/impress-frontend:v1.10.0
+          image: lasuite/impress-frontend:v2.0.0
           env:
             - name: "NEXT_PUBLIC_API_ORIGIN"
               value: "https://docs.la-suite.apps.digilab.network"

--- a/manifests/deployment-yprovider.yaml
+++ b/manifests/deployment-yprovider.yaml
@@ -17,7 +17,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: docs
-          image: lasuite/impress-y-provider:v1.10.0
+          image: lasuite/impress-y-provider:v2.0.0
           env:
             - name: "COLLABORATION_LOGGING"
               value: "true"


### PR DESCRIPTION
# Description

Upgrade naar docs 2.0.0: https://github.com/suitenumerique/docs/releases/tag/v2.0.0

NB: Upgrade procedure moet gevolgd worden: https://github.com/suitenumerique/docs/blob/main/UPGRADE.md
